### PR TITLE
Fix copying containers

### DIFF
--- a/src/message.cpp
+++ b/src/message.cpp
@@ -346,13 +346,17 @@ void MessageIter::copy_data(MessageIter &to)
       debug_log("copying compound type: %c[%s]", from.type(), sig);
 
       MessageIter to_container(to.msg());
-      dbus_message_iter_open_container
+      dbus_bool_t ret = dbus_message_iter_open_container
       (
         (DBusMessageIter *) & (to._iter),
         from.type(),
-        from.type() == DBUS_TYPE_VARIANT ? NULL : sig,
+        (from.type() == DBUS_TYPE_VARIANT || from.type() == DBUS_TYPE_ARRAY) ? sig : NULL,
         (DBusMessageIter *) & (to_container._iter)
       );
+      if (!ret)
+      {
+        throw ErrorNoMemory("Unable to append container");
+      }
 
       from_container.copy_data(to_container);
       to.close_container(to_container);


### PR DESCRIPTION
dbus_message_iter_open_container() needs a signature argument for variants
and arrays, and NULL for structs and dict entries.

(See https://dbus.freedesktop.org/doc/api/html/group__DBusMessage.html#ga943150f4e87fd8507da224d22c266100)

I also added a check for the return value of dbus_message_iter_open_container() (which is false for out of memory conditions or when one of the assertions fails).

[libdbus-c++-variant.cpp](https://github.com/andreas-volz/dbus-cplusplus/files/140400/libdbus-c.-variant.cpp.txt) contains a test case which will show the issue.
