### PR TITLE
use POSIX poll.h instead of sys/poll.h

### DIFF
--- a/src/eventloop-integration.cpp
+++ b/src/eventloop-integration.cpp
@@ -36,7 +36,7 @@
 /* STD */
 #include <string.h>
 #include <cassert>
-#include <sys/poll.h>
+#include <poll.h>
 #include <fcntl.h>
 #include <unistd.h>
 

--- a/src/eventloop.cpp
+++ b/src/eventloop.cpp
@@ -28,7 +28,7 @@
 #include <dbus-c++/eventloop.h>
 #include <dbus-c++/debug.h>
 
-#include <sys/poll.h>
+#include <poll.h>
 #include <sys/time.h>
 
 #include <dbus/dbus.h>

--- a/src/pipe.cpp
+++ b/src/pipe.cpp
@@ -32,7 +32,7 @@
 
 /* STD */
 #include <unistd.h>
-#include <sys/poll.h>
+#include <poll.h>
 #include <fcntl.h>
 #include <errno.h>
 #include <cassert>


### PR DESCRIPTION
POSIX specifies that <poll.h> is the correct header to
include for poll()
  http://pubs.opengroup.org/onlinepubs/009695399/functions/poll.html
whereas <sys/poll.h> is only needed for ancient glibc (<2.3),
so let's follow POSIX instead.

As a side-effect, this silences compilation warnings when
compiling against the musl C-library such as:

| In file included from ../../libdbus-c++-0.9.0/src/eventloop.cpp:31:0:
| <sysroot>/usr/include/sys/poll.h:1:2: warning: #warning redirecting incorrect #include <sys/poll.h> to <poll.h> [-Wcpp]
|  #warning redirecting incorrect #include <sys/poll.h> to <poll.h>
|   ^~~~~~~
| In file included from ../../libdbus-c++-0.9.0/src/eventloop-integration.cpp:39:0:
| <sysroot>/usr/include/sys/poll.h:1:2: warning: #warning redirecting incorrect #include <sys/poll.h> to <poll.h> [-Wcpp]
|  #warning redirecting incorrect #include <sys/poll.h> to <poll.h>
|   ^~~~~~~

Signed-off-by: André Draszik <git@andred.net>