### PR TITLE
Add overload to create a DBus::Error using a std::string

### DIFF
--- a/include/dbus-c++/error.h
+++ b/include/dbus-c++/error.h
@@ -46,6 +46,8 @@ public:
 
   Error(const char *name, const char *message);
 
+  Error(const std::string &name, const std::string &message);
+
   Error(Message &);
 
   ~Error() throw();
@@ -58,6 +60,8 @@ public:
 
   void set(const char *name, const char *message);
   // parameters MUST be static strings
+
+  void set(const std::string &name, const std::string &message);
 
   bool is_set() const;
 

--- a/src/error.cpp
+++ b/src/error.cpp
@@ -52,6 +52,12 @@ Error::Error(const char *name, const char *message)
   set(name, message);
 }
 
+Error::Error(const std::string &name, const std::string &message)
+  : _int(new InternalError)
+{
+  set(name, message);
+}
+
 Error::Error(Message &m)
   : _int(new InternalError)
 {
@@ -80,6 +86,11 @@ bool Error::is_set() const
 void Error::set(const char *name, const char *message)
 {
   dbus_set_error_const(&(_int->error), name, message);
+}
+
+void Error::set(const std::string &name, const std::string &message)
+{
+  dbus_set_error(&(_int->error), name.c_str(), "%s", message.c_str());
 }
 
 const char *Error::what() const throw()


### PR DESCRIPTION
Add a new constructor and set() overload to DBus::Error which allow
specifying the name and message as std::strings. These overloads can be used
with non-static strings (unlike the overloads which accept a const char* and which call dbus_set_error_const()).