### PR TITLE
pipe.cpp: fixed compile error with gcc 7.2

### DIFF
--- a/src/pipe.cpp
+++ b/src/pipe.cpp
@@ -83,5 +83,5 @@ ssize_t Pipe::read(void *buffer, unsigned int &nbytes)
 void Pipe::signal()
 {
   // TODO: ignoring return of read/write generates warning; maybe relevant for eventloop work...
-  ::write(_fd_write, '\0', 1);
+  ::write(_fd_write, "", 1);
 }


### PR DESCRIPTION
This is inspired by commit acbfee07ec526bd533fcc7560fb3ae609f7a1dee
from juanrubio