### PR TITLE
Make Pipe() functionality more reliable

### DIFF
--- a/include/dbus-c++/eventloop.h
+++ b/include/dbus-c++/eventloop.h
@@ -27,6 +27,7 @@
 
 #include <pthread.h>
 #include <list>
+#include <vector>
 
 #include "api.h"
 #include "util.h"
@@ -205,7 +206,7 @@ public:
 
   virtual ~DefaultMainLoop();
 
-  virtual void dispatch();
+  virtual void dispatch(std::vector<int>& pipe_fds);
 
   int _fdunlock[2];
 private:

--- a/src/eventloop-integration.cpp
+++ b/src/eventloop-integration.cpp
@@ -145,8 +145,18 @@ void BusDispatcher::del_pipe(Pipe *pipe)
 
 void BusDispatcher::do_iteration()
 {
+    std::vector<int> pipe_fds;
+    for (std::list <Pipe *>::iterator p_it = pipe_list.begin();
+         p_it != pipe_list.end();
+         ++p_it)
+    {
+        Pipe *read_pipe = *p_it;
+        pipe_fds.push_back(read_pipe->_fd_read);
+    }
+
+
   dispatch_pending();
-  dispatch();
+  dispatch(pipe_fds);
 }
 
 Timeout *BusDispatcher::add_timeout(Timeout::Internal *ti)


### PR DESCRIPTION
1. Enhance eventloop-integration to have BusDispatcher monitor
   incoming Pipe() FDs so incoming Pipe() data can be quickly handled.

2. Fix reading and writing to pipe to handle partial reads, partial
   writes, and EINTR.

3. Fix Pipe::signal() to follow protocol of read()/write() by writing
   data starting with size (number of bytes). Implemented by using
   Pipe::write() rather than a raw ::write().