### PR TITLE
Add "share_private" argument to copy constructor

### DIFF
--- a/include/dbus-c++/message.h
+++ b/include/dbus-c++/message.h
@@ -163,7 +163,7 @@ public:
 
   Message(Private *, bool incref = true);
 
-  Message(const Message &m);
+  Message(const Message &m, bool share_private = true);
 
   ~Message();
 
@@ -227,6 +227,8 @@ public:
 
   ErrorMessage(const Message &, const char *name, const char *message);
 
+  ErrorMessage(const ErrorMessage &m, bool share_private = true);
+
   const char *name() const;
 
   bool name(const char *n);
@@ -244,6 +246,8 @@ public:
   SignalMessage(const char *name);
 
   SignalMessage(const char *path, const char *interface, const char *name);
+
+  SignalMessage(const SignalMessage &m, bool share_private = true);
 
   const char *interface() const;
 
@@ -273,6 +277,8 @@ public:
 
   CallMessage(const char *dest, const char *path, const char *iface, const char *method);
 
+  CallMessage(const CallMessage &m, bool share_private = true);
+
   const char *interface() const;
 
   bool interface(const char *i);
@@ -300,6 +306,8 @@ class DXXAPI ReturnMessage : public Message
 public:
 
   ReturnMessage(const CallMessage &callee);
+
+  ReturnMessage(const ReturnMessage &m, bool share_private = true);
 
   const char *signature() const;
 };


### PR DESCRIPTION
The smart pointer C++ reference counting utilized by the DBus::Private
_pvt pointer isn't thread safe, so sharing/copying DBus:Message
instances across threads leads to crashes/DBus C library asserts as
Private pointer objects are released prematurely.

Rather than trying to make the reference counting itself thread-safe,
and slowing down single threaded usage, a share_private optional
argument is added the copy constructor. The share_private argument
defaults to true, which preserves the existing behavior of sharing the
Private* and associated reference counting.

If the share_private copy constructor argument is instead given as
false, a new instance is created with a new Private _pvt pointer and
unique reference count, which is logically "divorced" from the
original except that is refers to the same C DBus library pointer.

Note that the C DBus library handles its reference counting in 
a thread safe manner.

This new object can then be utilized by another thread without
affecting the reference counting of the original.